### PR TITLE
Add entry_point to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,10 @@ setup(
     url = 'https://github.com/toofishes/python-pgpdump',
     keywords = 'pgp gpg rfc2440 rfc4880 crypto cryptography',
     classifiers = classifiers,
+    entry_points={
+        'console_scripts': [
+            'pgpdump = pgpdump.__main__:main',
+        ],
+    },
     packages = ['pgpdump']
 )


### PR DESCRIPTION
This makes `pip install pgpdump` to install the `pgpdump` script
into the user's $PATH (or `.local/bin/`)

See
https://chriswarrick.com/blog/2014/09/15/python-apps-the-right-way-entry_points-and-scripts/